### PR TITLE
Remove `dub.co` (not a link shortener)

### DIFF
--- a/js-link-shorteners/src/link-shorteners.txt
+++ b/js-link-shorteners/src/link-shorteners.txt
@@ -30,7 +30,6 @@ cutt.ly
 da.gd
 destyy.com
 dik.si
-dub.co
 dub.sh
 etiny.ios
 extbr.com

--- a/py-link-shorteners/link_shorteners/link-shorteners.txt
+++ b/py-link-shorteners/link_shorteners/link-shorteners.txt
@@ -30,7 +30,6 @@ cutt.ly
 da.gd
 destyy.com
 dik.si
-dub.co
 dub.sh
 etiny.ios
 extbr.com


### PR DESCRIPTION
Founder of [Dub](https://dub.co/) here – the `dub.co` domain is strictly used for our marketing site and will never contain any user-generated short links, would appreciate it if it can be removed from this list. 

Thank you in advance!